### PR TITLE
Add Laravel 13 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
 
       - name: Check PHP code style
         run: ./vendor/bin/pint --test
@@ -49,7 +49,7 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci --exclude-group=performance ${{ matrix.php == '8.4' && matrix.stability == 'prefer-stable' && '--coverage --min=80' || '' }}
+        run: vendor/bin/pest --ci --exclude-group=performance ${{ matrix.php == '8.4' && matrix.stability == 'prefer-stable' && '--coverage --min=80 --coverage-clover=coverage.xml' || '' }}
 
       - name: Upload coverage reports to Codecov
         if: matrix.php == '8.4' && matrix.stability == 'prefer-stable'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3]
-        laravel: ['13.x-dev', '12.*']
+        laravel: ['13.*', '12.*']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: '13.x-dev'
-            testbench: '11.x-dev'
+          - laravel: '13.*'
+            testbench: '11.*'
           - laravel: '12.*'
             testbench: '10.*'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3]
-        laravel: [12.*]
+        laravel: ['13.x-dev', '12.*']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 12.*
-            testbench: 10.*
+          - laravel: '13.x-dev'
+            testbench: '11.x-dev'
+          - laravel: '12.*'
+            testbench: '10.*'
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ configuration file or overridden at runtime for debugging purposes.
 
 ## Requirements
 
-- Laravel 12.11.0+
+- Laravel 12.11.0+ or Laravel 13.x
 - PHP 8.3+
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,5 @@
             }
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
     ],
     "require": {
         "php": "^8.3",
-        "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^12.11.0"
+        "illuminate/contracts": "^12.11.0 || ^13.0",
+        "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1",
-        "larastan/larastan": "^3.0",
-        "orchestra/testbench": "^10.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
+        "pestphp/pest": "^3.0 || ^4.0",
+        "pestphp/pest-plugin-arch": "^3.0 || ^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0 || ^4.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,9 +28,4 @@
             <directory suffix=".php">./src</directory>
         </include>
     </source>
-    <coverage>
-        <report>
-            <clover outputFile="coverage.xml"/>
-        </report>
-    </coverage>
 </phpunit>

--- a/src/ScopedLogger.php
+++ b/src/ScopedLogger.php
@@ -53,7 +53,7 @@ class ScopedLogger implements LoggerInterface
     /**
      * Get merged scopes (channel-specific overrides global)
      *
-     * @return array<string, string|false|\Closure>
+     * @return array<string, string|false|Closure>
      */
     protected function getMergedScopes(): array
     {

--- a/src/ScopedLoggerServiceProvider.php
+++ b/src/ScopedLoggerServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tibbs\ScopedLogger;
 
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\LogManager;
 use Illuminate\Support\Facades\Log;
 use Spatie\LaravelPackageTools\Package;
@@ -29,7 +30,7 @@ class ScopedLoggerServiceProvider extends PackageServiceProvider
     public function packageRegistered(): void
     {
         // Extend the Log manager to use our ScopedLogger
-        $this->app->extend('log', function (LogManager $logManager, \Illuminate\Contracts\Foundation\Application $app) {
+        $this->app->extend('log', function (LogManager $logManager, Application $app) {
             return new ScopedLogManager($logManager, $app);
         });
 

--- a/tests/Commands/TestScopeCommandTest.php
+++ b/tests/Commands/TestScopeCommandTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Artisan;
 use Tibbs\ScopedLogger\Commands\TestScopeCommand;
+use Tibbs\ScopedLogger\Configuration\Configuration;
 
 describe('TestScopeCommand', function () {
     it('tests exact scope match', function () {
@@ -104,15 +106,15 @@ describe('TestScopeCommand', function () {
 
         // Debug: check that Configuration loads channel scopes correctly
         $configArray = config('scoped-logger', []);
-        $config = \Tibbs\ScopedLogger\Configuration\Configuration::fromArray($configArray);
+        $config = Configuration::fromArray($configArray);
         expect($config->scopesForChannel('slack'))->toBe(['payment' => 'error']);
 
         // Run command and capture output for debugging
-        \Illuminate\Support\Facades\Artisan::call('scoped-logger:test', [
+        Artisan::call('scoped-logger:test', [
             'scope' => 'payment',
             '--channel' => 'slack',
         ]);
-        $output = \Illuminate\Support\Facades\Artisan::output();
+        $output = Artisan::output();
 
         // Debug: check output contains expected text
         expect($output)->toContain('Testing scope');
@@ -205,11 +207,11 @@ describe('TestScopeCommand', function () {
             ],
         ]);
 
-        \Illuminate\Support\Facades\Artisan::call('scoped-logger:test', [
+        Artisan::call('scoped-logger:test', [
             'scope' => 'verbose',
             '--channel' => 'slack',
         ]);
-        $output = \Illuminate\Support\Facades\Artisan::output();
+        $output = Artisan::output();
 
         expect($output)->toContain('SUPPRESSED');
         expect($output)->toContain('channel override');
@@ -228,11 +230,11 @@ describe('TestScopeCommand', function () {
             ],
         ]);
 
-        \Illuminate\Support\Facades\Artisan::call('scoped-logger:test', [
+        Artisan::call('scoped-logger:test', [
             'scope' => 'App\\Services\\PaymentService',
             '--channel' => 'slack',
         ]);
-        $output = \Illuminate\Support\Facades\Artisan::output();
+        $output = Artisan::output();
 
         expect($output)->toContain('Matched Pattern');
         expect($output)->toContain('error');

--- a/tests/ConfigValidationTest.php
+++ b/tests/ConfigValidationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Spatie\LaravelPackageTools\Package;
 use Tibbs\ScopedLogger\ScopedLoggerServiceProvider;
 
 describe('Configuration Validation', function () {
@@ -9,7 +10,7 @@ describe('Configuration Validation', function () {
         config(['scoped-logger.default_level' => 'invalid']);
 
         $provider = new ScopedLoggerServiceProvider($this->app);
-        $provider->configurePackage(new \Spatie\LaravelPackageTools\Package);
+        $provider->configurePackage(new Package);
 
         expect(fn () => $provider->packageBooted())
             ->toThrow(
@@ -27,7 +28,7 @@ describe('Configuration Validation', function () {
         ]);
 
         $provider = new ScopedLoggerServiceProvider($this->app);
-        $provider->configurePackage(new \Spatie\LaravelPackageTools\Package);
+        $provider->configurePackage(new Package);
 
         expect(fn () => $provider->packageBooted())
             ->toThrow(
@@ -45,7 +46,7 @@ describe('Configuration Validation', function () {
         ]);
 
         $provider = new ScopedLoggerServiceProvider($this->app);
-        $provider->configurePackage(new \Spatie\LaravelPackageTools\Package);
+        $provider->configurePackage(new Package);
 
         // Should not throw
         $provider->packageBooted();
@@ -65,7 +66,7 @@ describe('Configuration Validation', function () {
             ]);
 
             $provider = new ScopedLoggerServiceProvider($this->app);
-            $provider->configurePackage(new \Spatie\LaravelPackageTools\Package);
+            $provider->configurePackage(new Package);
 
             // Should not throw
             $provider->packageBooted();
@@ -81,7 +82,7 @@ describe('Configuration Validation', function () {
         ]);
 
         $provider = new ScopedLoggerServiceProvider($this->app);
-        $provider->configurePackage(new \Spatie\LaravelPackageTools\Package);
+        $provider->configurePackage(new Package);
 
         expect(fn () => $provider->packageBooted())
             ->toThrow(
@@ -100,7 +101,7 @@ describe('Configuration Validation', function () {
             ]);
 
             $provider = new ScopedLoggerServiceProvider($this->app);
-            $provider->configurePackage(new \Spatie\LaravelPackageTools\Package);
+            $provider->configurePackage(new Package);
 
             // Should not throw
             $provider->packageBooted();

--- a/tests/DebugModeTest.php
+++ b/tests/DebugModeTest.php
@@ -97,7 +97,7 @@ describe('Debug Mode', function () {
         $logger = new ScopedLogger($mockLogger, $config);
 
         // Use reflection to test addDebugInfoToContext directly
-        $reflection = new \ReflectionClass($logger);
+        $reflection = new ReflectionClass($logger);
         $method = $reflection->getMethod('addDebugInfoToContext');
         $method->setAccessible(true);
 

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -25,6 +25,6 @@ describe('ScopedLogger Facade', function () {
 
     it('works via the facade', function () {
         expect(fn () => ScopedLogger::scope('test-scope')->info('test message'))
-            ->not->toThrow(\Exception::class);
+            ->not->toThrow(Exception::class);
     });
 });

--- a/tests/LogFacadeIntegrationTest.php
+++ b/tests/LogFacadeIntegrationTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Log;
+use Tibbs\ScopedLogger\ScopedLogger;
 
 describe('Log Facade Integration', function () {
     beforeEach(function () {
@@ -26,14 +27,14 @@ describe('Log Facade Integration', function () {
         // But let's first check if Log returns our ScopedLogger
         $logger = Log::channel();
 
-        expect($logger)->toBeInstanceOf(\Tibbs\ScopedLogger\ScopedLogger::class);
+        expect($logger)->toBeInstanceOf(ScopedLogger::class);
     });
 
     it('supports scope method on Log facade', function () {
         $logger = Log::channel();
 
         // Check that it's our ScopedLogger which has scope method
-        expect($logger)->toBeInstanceOf(\Tibbs\ScopedLogger\ScopedLogger::class)
+        expect($logger)->toBeInstanceOf(ScopedLogger::class)
             ->and(method_exists($logger, 'scope'))->toBeTrue();
     });
 
@@ -43,18 +44,18 @@ describe('Log Facade Integration', function () {
 
         // This is a ScopedLogger, so scope() should work
         expect(fn () => $logger->scope('error-only')->debug('test'))
-            ->not->toThrow(\Exception::class);
+            ->not->toThrow(Exception::class);
     });
 
     it('can chain scope with Log facade directly', function () {
         // Test that we can actually use Log facade with scope
         // This should NOT throw an error
-        expect(fn () => Log::scope('test-scope'))->not->toThrow(\Exception::class);
+        expect(fn () => Log::scope('test-scope'))->not->toThrow(Exception::class);
     });
 
     it('can log with Log facade and scope', function () {
         // This is the real test - can we actually use Log::scope()->info()?
         expect(fn () => Log::scope('test-scope')->info('test message'))
-            ->not->toThrow(\Exception::class);
+            ->not->toThrow(Exception::class);
     });
 });

--- a/tests/PatternMatchingIntegrationTest.php
+++ b/tests/PatternMatchingIntegrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Psr\Log\LoggerInterface;
 use Tibbs\ScopedLogger\ScopedLogger;
+use Tibbs\ScopedLogger\Tests\Fixtures\TestService;
 
 describe('Pattern Matching Integration', function () {
     beforeEach(function () {
@@ -168,6 +169,6 @@ describe('Pattern Matching Integration', function () {
             ->once()
             ->with('debug', 'test', []);
 
-        $scope = (new Tibbs\ScopedLogger\Tests\Fixtures\TestService)->testPatternMatching($logger);
+        $scope = (new TestService)->testPatternMatching($logger);
     });
 });

--- a/tests/RuntimeModificationTest.php
+++ b/tests/RuntimeModificationTest.php
@@ -112,7 +112,7 @@ describe('Runtime Modification', function () {
         $logger = new ScopedLogger($mockLogger, $config);
 
         expect(fn () => $logger->setRuntimeLevel('payment', 'invalid'))
-            ->toThrow(\InvalidArgumentException::class);
+            ->toThrow(InvalidArgumentException::class);
     });
 
     it('throws exception when setting runtime level with empty scope', function () {
@@ -127,7 +127,7 @@ describe('Runtime Modification', function () {
         $logger = new ScopedLogger($mockLogger, $config);
 
         expect(fn () => $logger->setRuntimeLevel('', 'debug'))
-            ->toThrow(\InvalidArgumentException::class, 'Scope identifier cannot be empty');
+            ->toThrow(InvalidArgumentException::class, 'Scope identifier cannot be empty');
     });
 
     it('runtime level overrides pattern matches', function () {

--- a/tests/ScopeResolverTest.php
+++ b/tests/ScopeResolverTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 use Tibbs\ScopedLogger\Configuration\Configuration;
 use Tibbs\ScopedLogger\Support\ScopeResolver;
+use Tibbs\ScopedLogger\Tests\Fixtures\ServiceWithClosure;
+use Tibbs\ScopedLogger\Tests\Fixtures\ServiceWithMethod;
+use Tibbs\ScopedLogger\Tests\Fixtures\ServiceWithProperty;
+use Tibbs\ScopedLogger\Tests\Fixtures\TestService;
 
 describe('ScopeResolver', function () {
     it('returns explicit scope when set', function () {
@@ -56,7 +60,7 @@ describe('ScopeResolver', function () {
         ]);
 
         $resolver = new ScopeResolver($config);
-        $scope = (new Tibbs\ScopedLogger\Tests\Fixtures\TestService)->getResolvedScope($resolver);
+        $scope = (new TestService)->getResolvedScope($resolver);
 
         expect($scope)->toBe('Tibbs\\ScopedLogger\\Tests\\Fixtures\\TestService');
     });
@@ -74,7 +78,7 @@ describe('ScopeResolver', function () {
         ]);
 
         $resolver = new ScopeResolver($config);
-        $scope = (new Tibbs\ScopedLogger\Tests\Fixtures\ServiceWithProperty)->getResolvedScope($resolver);
+        $scope = (new ServiceWithProperty)->getResolvedScope($resolver);
 
         expect($scope)->toBe('custom-payment-scope');
     });
@@ -92,7 +96,7 @@ describe('ScopeResolver', function () {
         ]);
 
         $resolver = new ScopeResolver($config);
-        $scope = (new Tibbs\ScopedLogger\Tests\Fixtures\ServiceWithMethod)->getResolvedScope($resolver);
+        $scope = (new ServiceWithMethod)->getResolvedScope($resolver);
 
         expect($scope)->toBe('method-based-scope');
     });
@@ -110,7 +114,7 @@ describe('ScopeResolver', function () {
         ]);
 
         $resolver = new ScopeResolver($config);
-        $scope = (new Tibbs\ScopedLogger\Tests\Fixtures\ServiceWithClosure)->getResolvedScope($resolver);
+        $scope = (new ServiceWithClosure)->getResolvedScope($resolver);
 
         expect($scope)->toBe('closure-scope');
     });
@@ -131,7 +135,7 @@ describe('ScopeResolver', function () {
         $resolver = new ScopeResolver($config);
         $resolver->setExplicitScope('explicit-scope');
 
-        $scope = (new Tibbs\ScopedLogger\Tests\Fixtures\TestService)->getResolvedScope($resolver);
+        $scope = (new TestService)->getResolvedScope($resolver);
 
         expect($scope)->toBe('explicit-scope');
     });
@@ -151,7 +155,7 @@ describe('ScopeResolver', function () {
         ]);
 
         $resolver = new ScopeResolver($config);
-        $scope = (new Tibbs\ScopedLogger\Tests\Fixtures\ServiceWithProperty)->getResolvedScope($resolver);
+        $scope = (new ServiceWithProperty)->getResolvedScope($resolver);
 
         expect($scope)->toBe('Tibbs\\ScopedLogger\\Tests\\Fixtures\\ServiceWithProperty');
     });

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -65,6 +65,6 @@ describe('ScopedLogManager', function () {
 
         // Log::info() goes through __call -> channel() -> ScopedLogger
         expect(fn () => Log::info('test message'))
-            ->not->toThrow(\Exception::class);
+            ->not->toThrow(Exception::class);
     });
 });

--- a/tests/ScopedLoggerTest.php
+++ b/tests/ScopedLoggerTest.php
@@ -126,7 +126,7 @@ describe('ScopedLogger', function () {
         $logger = new ScopedLogger($this->mockLogger, $this->config);
 
         // Use reflection to test the protected shouldLog method
-        $reflection = new \ReflectionClass($logger);
+        $reflection = new ReflectionClass($logger);
         $method = $reflection->getMethod('shouldLog');
         $method->setAccessible(true);
 


### PR DESCRIPTION
## Summary
- Widen dependency constraints to support both Laravel 12 and the upcoming Laravel 13 (currently dev)
- Add Laravel 13 (`13.x-dev`) to the CI test matrix alongside existing Laravel 12 coverage
- Bump Pest constraint to `^3.0 || ^4.0` since testbench 11.x requires PHPUnit 12, which needs Pest 4

## Details

**composer.json changes:**
| Package | Before | After |
|---------|--------|-------|
| `illuminate/contracts` | `^12.11.0` | `^12.11.0 \|\| ^13.0` |
| `orchestra/testbench` | `^10.0` | `^10.0 \|\| ^11.0` |
| `pestphp/pest` | `^3.0` | `^3.0 \|\| ^4.0` |
| `pestphp/pest-plugin-arch` | `^3.0` | `^3.0 \|\| ^4.0` |
| `pestphp/pest-plugin-laravel` | `^3.0` | `^3.0 \|\| ^4.0` |

**CI matrix expansion:** 2 PHP versions × 2 Laravel versions × 2 stability modes = 8 jobs

Composer automatically resolves the correct Pest version per Laravel: Pest 3 + PHPUnit 11 for Laravel 12, Pest 4 + PHPUnit 12 for Laravel 13.

**Verified locally:** All 136 tests pass and PHPStan reports no errors on both Laravel 12 stable and Laravel 13 dev.

## Test plan
- [ ] CI passes for all 8 matrix combinations
- [ ] When Laravel 13 goes stable, swap `13.x-dev` → `13.*` and `11.x-dev` → `11.*` in CI matrix