### PR TITLE
Improve test coverage for edge cases

### DIFF
--- a/tests/Commands/ListScopesCommandEdgeCasesTest.php
+++ b/tests/Commands/ListScopesCommandEdgeCasesTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Tibbs\ScopedLogger\Commands\ListScopesCommand;
+
+describe('ListScopesCommand Edge Cases', function () {
+    it('formats closure levels in scope list', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'info',
+            'scoped-logger.scopes' => [
+                'payment' => fn () => 'debug',
+                'auth' => 'error',
+            ],
+        ]);
+
+        $this->artisan(ListScopesCommand::class)
+            ->expectsOutputToContain('Global Scopes')
+            ->expectsOutputToContain('payment')
+            ->expectsOutputToContain('auth')
+            ->assertSuccessful();
+    });
+
+    it('formats closure that returns false as suppressed', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'info',
+            'scoped-logger.scopes' => [
+                'noisy' => fn () => false,
+            ],
+        ]);
+
+        $this->artisan(ListScopesCommand::class)
+            ->expectsOutputToContain('SUPPRESSED')
+            ->assertSuccessful();
+    });
+
+    it('sorts scopes by level when requested', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'info',
+            'scoped-logger.scopes' => [
+                'payment' => 'debug',
+                'auth' => 'error',
+                'api' => 'warning',
+            ],
+        ]);
+
+        $this->artisan(ListScopesCommand::class, ['--sort' => 'level'])
+            ->expectsOutputToContain('payment')
+            ->expectsOutputToContain('auth')
+            ->expectsOutputToContain('api')
+            ->assertSuccessful();
+    });
+
+    it('skips empty channel scope arrays', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'info',
+            'scoped-logger.scopes' => [
+                'payment' => 'debug',
+            ],
+            'scoped-logger.channel_scopes' => [
+                'daily' => [],
+                'slack' => ['alert-scope' => 'error'],
+            ],
+        ]);
+
+        $this->artisan(ListScopesCommand::class)
+            ->expectsOutputToContain('Channel-Specific Scopes')
+            ->expectsOutputToContain('slack')
+            ->expectsOutputToContain('alert-scope')
+            ->assertSuccessful();
+    });
+
+    it('handles closure that returns non-string as info', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'info',
+            'scoped-logger.scopes' => [
+                'oddscope' => fn () => 42,
+            ],
+        ]);
+
+        $this->artisan(ListScopesCommand::class)
+            ->expectsOutputToContain('info')
+            ->assertSuccessful();
+    });
+});

--- a/tests/Commands/TestScopeCommandEdgeCasesTest.php
+++ b/tests/Commands/TestScopeCommandEdgeCasesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Tibbs\ScopedLogger\Commands\TestScopeCommand;
+
+describe('TestScopeCommand Edge Cases', function () {
+    it('shows warning when scoped logger is disabled', function () {
+        config([
+            'scoped-logger.enabled' => false,
+        ]);
+
+        $this->artisan(TestScopeCommand::class, ['scope' => 'payment'])
+            ->expectsOutputToContain('disabled')
+            ->assertFailed();
+    });
+
+    it('evaluates closure levels for exact scope match', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'info',
+            'scoped-logger.scopes' => [
+                'payment' => fn () => 'debug',
+            ],
+        ]);
+
+        $this->artisan(TestScopeCommand::class, ['scope' => 'payment'])
+            ->expectsOutputToContain('debug')
+            ->assertSuccessful();
+    });
+
+    it('evaluates closure levels for pattern-matched scope', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'info',
+            'scoped-logger.scopes' => [
+                'App\Services\*' => fn () => 'warning',
+            ],
+        ]);
+
+        $this->artisan(TestScopeCommand::class, ['scope' => 'App\Services\PaymentService'])
+            ->expectsOutputToContain('warning')
+            ->expectsOutputToContain('Matched Pattern')
+            ->assertSuccessful();
+    });
+
+    it('handles closure that returns false for suppressed scope', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'info',
+            'scoped-logger.scopes' => [
+                'noisy' => fn () => false,
+            ],
+        ]);
+
+        $this->artisan(TestScopeCommand::class, ['scope' => 'noisy'])
+            ->expectsOutputToContain('SUPPRESSED')
+            ->assertSuccessful();
+    });
+
+    it('handles closure that returns non-string value', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'info',
+            'scoped-logger.scopes' => [
+                'oddscope' => fn () => 42,
+            ],
+        ]);
+
+        // Non-string closure return becomes null, which means default level is used
+        $this->artisan(TestScopeCommand::class, ['scope' => 'oddscope'])
+            ->expectsOutputToContain('default')
+            ->assertSuccessful();
+    });
+});

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Tibbs\ScopedLogger\Configuration\Configuration;
+use Tibbs\ScopedLogger\Exceptions\InvalidScopeConfigurationException;
+
+describe('Configuration', function () {
+    it('throws exception for non-string metadata_base_path', function () {
+        expect(fn () => Configuration::fromArray([
+            'metadata_base_path' => 123,
+        ]))->toThrow(InvalidScopeConfigurationException::class);
+    });
+
+    it('returns metadata configuration values', function () {
+        $config = Configuration::fromArray([
+            'include_metadata' => true,
+            'metadata_skip_vendor' => false,
+            'metadata_relative_paths' => false,
+            'metadata_base_path' => '/custom/path',
+            'debug_mode' => true,
+        ]);
+
+        expect($config->includeMetadata())->toBeTrue()
+            ->and($config->metadataSkipVendor())->toBeFalse()
+            ->and($config->metadataRelativePaths())->toBeFalse()
+            ->and($config->metadataBasePath())->toBe('/custom/path')
+            ->and($config->debugMode())->toBeTrue();
+    });
+
+    it('uses default values when config array is empty', function () {
+        $config = Configuration::fromArray([]);
+
+        expect($config->isEnabled())->toBeTrue()
+            ->and($config->defaultLevel())->toBe('info')
+            ->and($config->scopes())->toBe([])
+            ->and($config->unknownScopeHandling())->toBe('exception')
+            ->and($config->channelScopes())->toBe([])
+            ->and($config->autoDetectionEnabled())->toBeTrue()
+            ->and($config->autoDetectionProperty())->toBe('log_scope')
+            ->and($config->autoDetectionStackDepth())->toBe(10)
+            ->and($config->autoDetectionSkipVendor())->toBeTrue()
+            ->and($config->disabledChannels())->toBe([])
+            ->and($config->includeScopeInContext())->toBeTrue()
+            ->and($config->scopeContextKey())->toBe('scope')
+            ->and($config->includeMetadata())->toBeFalse()
+            ->and($config->metadataSkipVendor())->toBeTrue()
+            ->and($config->metadataRelativePaths())->toBeTrue()
+            ->and($config->metadataBasePath())->toBeNull()
+            ->and($config->debugMode())->toBeFalse();
+    });
+
+    it('accepts null metadata_base_path', function () {
+        $config = Configuration::fromArray([
+            'metadata_base_path' => null,
+        ]);
+
+        expect($config->metadataBasePath())->toBeNull();
+    });
+
+    it('accepts string metadata_base_path', function () {
+        $config = Configuration::fromArray([
+            'metadata_base_path' => '/some/path',
+        ]);
+
+        expect($config->metadataBasePath())->toBe('/some/path');
+    });
+
+    it('returns scopes for specific channel', function () {
+        $config = Configuration::fromArray([
+            'channel_scopes' => [
+                'daily' => ['payment' => 'debug'],
+                'slack' => ['auth' => 'error'],
+            ],
+        ]);
+
+        expect($config->scopesForChannel('daily'))->toBe(['payment' => 'debug'])
+            ->and($config->scopesForChannel('slack'))->toBe(['auth' => 'error'])
+            ->and($config->scopesForChannel('nonexistent'))->toBe([]);
+    });
+});

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Tibbs\ScopedLogger\Facades\ScopedLogger;
+use Tibbs\ScopedLogger\ScopedLogger as ScopedLoggerInstance;
+
+describe('ScopedLogger Facade', function () {
+    beforeEach(function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'info',
+            'scoped-logger.scopes' => [
+                'test-scope' => 'debug',
+            ],
+            'scoped-logger.auto_detection' => ['enabled' => false],
+        ]);
+    });
+
+    it('resolves from the container', function () {
+        $resolved = app('scoped-logger');
+
+        expect($resolved)->toBeInstanceOf(ScopedLoggerInstance::class);
+    });
+
+    it('works via the facade', function () {
+        expect(fn () => ScopedLogger::scope('test-scope')->info('test message'))
+            ->not->toThrow(\Exception::class);
+    });
+});

--- a/tests/InvalidScopeConfigurationExceptionTest.php
+++ b/tests/InvalidScopeConfigurationExceptionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Tibbs\ScopedLogger\Exceptions\InvalidScopeConfigurationException;
+
+describe('InvalidScopeConfigurationException', function () {
+    it('creates exception for invalid pattern', function () {
+        $exception = InvalidScopeConfigurationException::invalidPattern('bad[pattern', 'contains invalid brackets');
+
+        expect($exception)->toBeInstanceOf(InvalidScopeConfigurationException::class)
+            ->and($exception->getMessage())->toContain('bad[pattern')
+            ->and($exception->getMessage())->toContain('contains invalid brackets')
+            ->and($exception->getMessage())->toContain('Patterns support wildcards');
+    });
+
+    it('creates exception for invalid config type', function () {
+        $exception = InvalidScopeConfigurationException::invalidConfigType('expected string, got integer');
+
+        expect($exception)->toBeInstanceOf(InvalidScopeConfigurationException::class)
+            ->and($exception->getMessage())->toContain('expected string, got integer')
+            ->and($exception->getMessage())->toContain('Check your config/scoped-logger.php');
+    });
+
+    it('creates exception for invalid level', function () {
+        $exception = InvalidScopeConfigurationException::invalidLevel('invalid', 'scopes.payment');
+
+        expect($exception)->toBeInstanceOf(InvalidScopeConfigurationException::class)
+            ->and($exception->getMessage())->toContain('invalid')
+            ->and($exception->getMessage())->toContain('scopes.payment');
+    });
+
+    it('creates exception for empty scope', function () {
+        $exception = InvalidScopeConfigurationException::emptyScope();
+
+        expect($exception)->toBeInstanceOf(InvalidScopeConfigurationException::class)
+            ->and($exception->getMessage())->toContain('cannot be empty');
+    });
+
+    it('creates exception for invalid unknown scope handling', function () {
+        $exception = InvalidScopeConfigurationException::invalidUnknownScopeHandling('invalid');
+
+        expect($exception)->toBeInstanceOf(InvalidScopeConfigurationException::class)
+            ->and($exception->getMessage())->toContain('invalid')
+            ->and($exception->getMessage())->toContain('exception')
+            ->and($exception->getMessage())->toContain('log')
+            ->and($exception->getMessage())->toContain('ignore');
+    });
+});

--- a/tests/PatternMatcherEdgeCasesTest.php
+++ b/tests/PatternMatcherEdgeCasesTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Tibbs\ScopedLogger\Support\PatternMatcher;
+
+describe('PatternMatcher Edge Cases', function () {
+    it('uses wildcard count as tiebreaker for same-length patterns', function () {
+        // Two patterns that are the same length but have different wildcard counts
+        // 'App\Svc\*\Pay' has 1 wildcard  (14 chars)
+        // 'App\*\?\Pay??'  would be different
+        // Let's create patterns where length is same but wildcard count differs
+        $matcher = new PatternMatcher([
+            'App\Svc\*' => 'debug',    // 9 chars, 1 wildcard
+            'App\Sv?\*' => 'warning',  // 9 chars, 2 wildcards
+        ]);
+
+        // 'App\Svc\Anything' matches 'App\Svc\*' (1 wildcard) and 'App\Sv?\*' (2 wildcards)
+        // The one with fewer wildcards should win
+        $result = $matcher->findMatch('App\Svc\Anything');
+
+        expect($result)->toBe('App\Svc\*');
+    });
+
+    it('prefers exact match over any pattern', function () {
+        $matcher = new PatternMatcher([
+            'App\Services\Payment' => 'error',
+            'App\Services\*' => 'debug',
+        ]);
+
+        $result = $matcher->findMatch('App\Services\Payment');
+
+        expect($result)->toBe('App\Services\Payment');
+    });
+
+    it('prefers longer patterns over shorter ones', function () {
+        $matcher = new PatternMatcher([
+            'App\*' => 'warning',
+            'App\Services\*' => 'debug',
+        ]);
+
+        $result = $matcher->findMatch('App\Services\PaymentService');
+
+        expect($result)->toBe('App\Services\*');
+    });
+
+    it('clears match cache', function () {
+        $matcher = new PatternMatcher([
+            'App\*' => 'debug',
+        ]);
+
+        // Populate cache
+        $matcher->findMatch('App\Services\Payment');
+        $stats = $matcher->getCacheStats();
+        expect($stats['cached_matches'])->toBe(1);
+
+        // Clear cache
+        $matcher->clearCache();
+        $stats = $matcher->getCacheStats();
+        expect($stats['cached_matches'])->toBe(0);
+    });
+});

--- a/tests/ScopeResolverEdgeCasesTest.php
+++ b/tests/ScopeResolverEdgeCasesTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+use Tibbs\ScopedLogger\Configuration\Configuration;
+use Tibbs\ScopedLogger\Support\ScopeResolver;
+
+describe('ScopeResolver Edge Cases', function () {
+    it('returns null when class does not exist', function () {
+        $config = Configuration::fromArray([
+            'scopes' => [],
+            'auto_detection' => ['enabled' => true],
+        ]);
+        $resolver = new ScopeResolver($config);
+
+        $reflection = new ReflectionClass($resolver);
+        $method = $reflection->getMethod('extractScopeFromClass');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($resolver, 'NonExistent\\Class\\Name');
+
+        expect($result)->toBeNull();
+    });
+
+    it('normalizes null scope value to null', function () {
+        $config = Configuration::fromArray([
+            'scopes' => [],
+        ]);
+        $resolver = new ScopeResolver($config);
+
+        $reflection = new ReflectionClass($resolver);
+        $method = $reflection->getMethod('normalizeScopeValue');
+        $method->setAccessible(true);
+
+        expect($method->invoke($resolver, null))->toBeNull();
+    });
+
+    it('normalizes non-string non-closure value to null', function () {
+        $config = Configuration::fromArray([
+            'scopes' => [],
+        ]);
+        $resolver = new ScopeResolver($config);
+
+        $reflection = new ReflectionClass($resolver);
+        $method = $reflection->getMethod('normalizeScopeValue');
+        $method->setAccessible(true);
+
+        expect($method->invoke($resolver, 123))->toBeNull()
+            ->and($method->invoke($resolver, true))->toBeNull()
+            ->and($method->invoke($resolver, []))->toBeNull();
+    });
+
+    it('normalizes closure scope value', function () {
+        $config = Configuration::fromArray([
+            'scopes' => [],
+        ]);
+        $resolver = new ScopeResolver($config);
+
+        $reflection = new ReflectionClass($resolver);
+        $method = $reflection->getMethod('normalizeScopeValue');
+        $method->setAccessible(true);
+
+        $closure = fn () => 'my-scope';
+        expect($method->invoke($resolver, $closure))->toBe('my-scope');
+
+        $nullClosure = fn () => null;
+        expect($method->invoke($resolver, $nullClosure))->toBeNull();
+
+        $intClosure = fn () => 42;
+        expect($method->invoke($resolver, $intClosure))->toBeNull();
+    });
+
+    it('identifies vendor namespace classes', function () {
+        $config = Configuration::fromArray([
+            'scopes' => [],
+            'auto_detection' => ['enabled' => true, 'skip_vendor' => true],
+        ]);
+        $resolver = new ScopeResolver($config);
+
+        $reflection = new ReflectionClass($resolver);
+        $method = $reflection->getMethod('isVendorClass');
+        $method->setAccessible(true);
+
+        expect($method->invoke($resolver, 'Illuminate\\Support\\Str', ''))->toBeTrue()
+            ->and($method->invoke($resolver, 'Laravel\\Sanctum\\Guard', ''))->toBeTrue()
+            ->and($method->invoke($resolver, 'Symfony\\Component\\HttpFoundation\\Request', ''))->toBeTrue()
+            ->and($method->invoke($resolver, 'Composer\\Autoload\\ClassLoader', ''))->toBeTrue()
+            ->and($method->invoke($resolver, 'PHPUnit\\Framework\\TestCase', ''))->toBeTrue()
+            ->and($method->invoke($resolver, 'Mockery\\MockInterface', ''))->toBeTrue()
+            ->and($method->invoke($resolver, 'Pest\\TestSuite', ''))->toBeTrue()
+            ->and($method->invoke($resolver, 'App\\Services\\PaymentService', ''))->toBeFalse();
+    });
+
+    it('checks skip paths', function () {
+        $config = Configuration::fromArray([
+            'scopes' => [],
+        ]);
+        $resolver = new ScopeResolver($config);
+
+        $reflection = new ReflectionClass($resolver);
+        $method = $reflection->getMethod('shouldSkipPath');
+        $method->setAccessible(true);
+
+        expect($method->invoke($resolver, '/app/vendor/laravel/framework/src/File.php', ['/vendor/']))
+            ->toBeTrue()
+            ->and($method->invoke($resolver, '/app/bootstrap/cache/packages.php', ['/bootstrap/']))
+            ->toBeTrue()
+            ->and($method->invoke($resolver, '/app/src/Services/Payment.php', ['/vendor/', '/bootstrap/']))
+            ->toBeFalse();
+    });
+
+    it('returns null when no valid calling class is found in stack', function () {
+        $config = Configuration::fromArray([
+            'scopes' => [],
+            'auto_detection' => [
+                'enabled' => true,
+                'stack_depth' => 30,
+                'skip_vendor' => true,
+            ],
+        ]);
+        $resolver = new ScopeResolver($config);
+
+        // When resolve() is called from test code, the stack frames will
+        // all be from vendor/test classes which get skipped
+        // The resolver should gracefully return null
+        $result = $resolver->resolve();
+
+        expect($result)->toBeNull();
+    });
+
+    it('exercises full stack traversal with vendor skipping via resolve', function () {
+        // With a large stack depth, resolve() traverses more frames,
+        // exercising vendor class and frameless entry skipping in findCallingClass
+        $config = Configuration::fromArray([
+            'scopes' => [],
+            'auto_detection' => [
+                'enabled' => true,
+                'stack_depth' => 30,
+                'skip_vendor' => true,
+                'skip_paths' => ['/some/test/path/'],
+            ],
+        ]);
+        $resolver = new ScopeResolver($config);
+
+        // All frames in the stack are package/vendor/test classes,
+        // so auto-detection finds nothing and resolve returns null
+        $result = $resolver->resolve();
+
+        expect($result)->toBeNull();
+    });
+
+    it('sets and gets explicit scopes', function () {
+        $config = Configuration::fromArray([
+            'scopes' => [],
+        ]);
+        $resolver = new ScopeResolver($config);
+
+        expect($resolver->hasExplicitScope())->toBeFalse()
+            ->and($resolver->getExplicitScopes())->toBe([]);
+
+        $resolver->setExplicitScopes(['payment', 'api']);
+
+        expect($resolver->hasExplicitScope())->toBeTrue()
+            ->and($resolver->getExplicitScopes())->toBe(['payment', 'api']);
+
+        $resolver->clearExplicitScope();
+
+        expect($resolver->hasExplicitScope())->toBeFalse()
+            ->and($resolver->getExplicitScopes())->toBe([]);
+    });
+
+    it('sets explicit scope to empty when null is passed', function () {
+        $config = Configuration::fromArray([
+            'scopes' => [],
+        ]);
+        $resolver = new ScopeResolver($config);
+
+        $resolver->setExplicitScope('payment');
+        expect($resolver->hasExplicitScope())->toBeTrue();
+
+        $resolver->setExplicitScope(null);
+        expect($resolver->hasExplicitScope())->toBeFalse()
+            ->and($resolver->getExplicitScopes())->toBe([]);
+    });
+});

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Log;
+use Tibbs\ScopedLogger\ScopedLogger;
+use Tibbs\ScopedLogger\ScopedLogManager;
+
+describe('ScopedLogManager', function () {
+    it('wraps default channel with ScopedLogger when enabled', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.scopes' => [],
+        ]);
+
+        $logger = Log::channel();
+
+        expect($logger)->toBeInstanceOf(ScopedLogger::class);
+    });
+
+    it('returns original logger when scoped logger is disabled', function () {
+        config([
+            'scoped-logger.enabled' => false,
+        ]);
+
+        $logger = Log::channel();
+
+        expect($logger)->not->toBeInstanceOf(ScopedLogger::class);
+    });
+
+    it('returns original logger for disabled channels', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.disabled_channels' => ['stack'],
+        ]);
+
+        $logger = Log::channel('stack');
+
+        expect($logger)->not->toBeInstanceOf(ScopedLogger::class);
+    });
+
+    it('aliases driver to channel', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.scopes' => [],
+        ]);
+
+        $manager = Log::getFacadeRoot();
+        expect($manager)->toBeInstanceOf(ScopedLogManager::class);
+
+        $fromDriver = $manager->driver();
+        $fromChannel = $manager->channel();
+
+        expect($fromDriver)->toBeInstanceOf(ScopedLogger::class);
+        expect($fromChannel)->toBeInstanceOf(ScopedLogger::class);
+    });
+
+    it('forwards calls via __call to wrapped channel', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.default_level' => 'debug',
+            'scoped-logger.scopes' => [],
+            'scoped-logger.auto_detection' => ['enabled' => false],
+        ]);
+
+        // Log::info() goes through __call -> channel() -> ScopedLogger
+        expect(fn () => Log::info('test message'))
+            ->not->toThrow(\Exception::class);
+    });
+});

--- a/tests/ScopedLoggerEdgeCasesTest.php
+++ b/tests/ScopedLoggerEdgeCasesTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Log\LoggerInterface;
+use Tibbs\ScopedLogger\ScopedLogger;
+
+describe('ScopedLogger Edge Cases', function () {
+    afterEach(function () {
+        Mockery::close();
+    });
+
+    it('returns absolute path when file does not start with base_path', function () {
+        $mockLogger = Mockery::mock(LoggerInterface::class);
+        $config = [
+            'enabled' => true,
+            'default_level' => 'debug',
+            'scopes' => ['test' => 'debug'],
+            'auto_detection' => ['enabled' => false],
+            'include_scope_in_context' => false,
+            'include_metadata' => false,
+            'metadata_relative_paths' => true,
+            'metadata_base_path' => '/some/other/base',
+        ];
+        $logger = new ScopedLogger($mockLogger, $config);
+
+        $reflection = new ReflectionClass($logger);
+        $method = $reflection->getMethod('formatFilePath');
+        $method->setAccessible(true);
+
+        // Path that doesn't start with the configured base path
+        $result = $method->invoke($logger, '/completely/different/path/file.php');
+
+        expect($result)->toBe('/completely/different/path/file.php');
+    });
+
+    it('returns file as-is when metadata_relative_paths is disabled', function () {
+        $mockLogger = Mockery::mock(LoggerInterface::class);
+        $config = [
+            'enabled' => true,
+            'default_level' => 'debug',
+            'scopes' => [],
+            'auto_detection' => ['enabled' => false],
+            'include_metadata' => false,
+            'metadata_relative_paths' => false,
+        ];
+        $logger = new ScopedLogger($mockLogger, $config);
+
+        $reflection = new ReflectionClass($logger);
+        $method = $reflection->getMethod('formatFilePath');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($logger, '/absolute/path/to/file.php');
+
+        expect($result)->toBe('/absolute/path/to/file.php');
+    });
+
+    it('returns unknown resolution method when auto-detection is disabled with non-explicit scope', function () {
+        $mockLogger = Mockery::mock(LoggerInterface::class);
+        $config = [
+            'enabled' => true,
+            'default_level' => 'debug',
+            'scopes' => ['test' => 'debug'],
+            'auto_detection' => ['enabled' => false],
+            'include_scope_in_context' => false,
+        ];
+        $logger = new ScopedLogger($mockLogger, $config);
+
+        $reflection = new ReflectionClass($logger);
+        $method = $reflection->getMethod('getResolutionMethod');
+        $method->setAccessible(true);
+
+        // scope is not null but no explicit scope and auto-detection disabled
+        $result = $method->invoke($logger, 'test');
+
+        expect($result)->toBe('unknown');
+    });
+
+    it('returns null metadata when no external frame is found', function () {
+        $mockLogger = Mockery::mock(LoggerInterface::class);
+        $config = [
+            'enabled' => true,
+            'default_level' => 'debug',
+            'scopes' => [],
+            'auto_detection' => ['enabled' => false],
+            'include_metadata' => true,
+            'metadata_skip_vendor' => true,
+        ];
+        $logger = new ScopedLogger($mockLogger, $config);
+
+        $reflection = new ReflectionClass($logger);
+        $method = $reflection->getMethod('extractMetadata');
+        $method->setAccessible(true);
+
+        // extractMetadata walks the stack looking for non-package frames
+        // In a test context, it will find test/vendor frames eventually
+        // but we can verify the structure of the return value
+        $result = $method->invoke($logger);
+
+        expect($result)->toBeArray()
+            ->and($result)->toHaveKeys(['file', 'line', 'class', 'function']);
+    });
+
+    it('merges shared context with log context', function () {
+        $mockLogger = Mockery::mock(LoggerInterface::class);
+        $config = [
+            'enabled' => true,
+            'default_level' => 'debug',
+            'scopes' => ['test' => 'debug'],
+            'auto_detection' => ['enabled' => false],
+            'include_scope_in_context' => true,
+            'scope_context_key' => 'scope',
+        ];
+        $logger = new ScopedLogger($mockLogger, $config);
+
+        $mockLogger->shouldReceive('log')
+            ->once()
+            ->with('info', 'test', Mockery::on(function ($context) {
+                return $context['shared_key'] === 'shared_value'
+                    && $context['call_key'] === 'call_value'
+                    && $context['scope'] === 'test';
+            }));
+
+        $logger->withContext(['shared_key' => 'shared_value']);
+        $logger->scope('test')->info('test', ['call_key' => 'call_value']);
+    });
+
+    it('handles getMergedScopes with channel-specific overrides', function () {
+        $mockLogger = Mockery::mock(LoggerInterface::class);
+        $config = [
+            'enabled' => true,
+            'default_level' => 'info',
+            'scopes' => [
+                'payment' => 'debug',
+                'auth' => 'error',
+            ],
+            'channel_scopes' => [
+                'daily' => [
+                    'payment' => 'warning', // override global
+                ],
+            ],
+            'auto_detection' => ['enabled' => false],
+            'include_scope_in_context' => false,
+        ];
+
+        // Create logger for 'daily' channel - payment should use 'warning' not 'debug'
+        $logger = new ScopedLogger($mockLogger, $config, 'daily');
+
+        // info is below warning threshold, so this should be blocked
+        $mockLogger->shouldNotReceive('log');
+
+        $logger->scope('payment')->info('test');
+    });
+});

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Tibbs\ScopedLogger\ScopedLogger;
+use Tibbs\ScopedLogger\ScopedLogManager;
+
+describe('ScopedLoggerServiceProvider', function () {
+    it('registers scoped-logger singleton in container', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.scopes' => [],
+            'scoped-logger.auto_detection' => ['enabled' => false],
+        ]);
+
+        $resolved = app('scoped-logger');
+
+        expect($resolved)->toBeInstanceOf(ScopedLogger::class);
+    });
+
+    it('extends the log manager with ScopedLogManager', function () {
+        $logManager = app('log');
+
+        expect($logManager)->toBeInstanceOf(ScopedLogManager::class);
+    });
+
+    it('resolves scoped-logger singleton consistently', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.scopes' => [],
+        ]);
+
+        $first = app('scoped-logger');
+        $second = app('scoped-logger');
+
+        expect($first)->toBe($second);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds 10 new test files with 51 tests and 129 assertions targeting all coverage gaps identified by the coverage report
- Raises overall test coverage from **91.2% to 97.9%**
- Brings 7 source files to **100% coverage** that were previously below (Facade, ScopedLogManager, ServiceProvider, Configuration, PatternMatcher, InvalidScopeConfigurationException, ListScopesCommand)

## New test files

| File | Covers |
|------|--------|
| `ScopedLogManagerTest.php` | Disabled channels, `driver()` alias, `__call` forwarding |
| `FacadeTest.php` | Facade resolution and usage |
| `InvalidScopeConfigurationExceptionTest.php` | `invalidPattern()` and `invalidConfigType()` factory methods |
| `ConfigurationTest.php` | `fromArray()` edge cases, metadata getters, defaults |
| `ServiceProviderTest.php` | Container singleton binding |
| `ScopeResolverEdgeCasesTest.php` | Value normalization, vendor detection, skip paths |
| `PatternMatcherEdgeCasesTest.php` | Wildcard count tiebreaker, cache operations |
| `ScopedLoggerEdgeCasesTest.php` | `formatFilePath`, resolution method, context merging |
| `ListScopesCommandEdgeCasesTest.php` | Closure formatting, sort by level, empty channels |
| `TestScopeCommandEdgeCasesTest.php` | Disabled warning, closure level evaluation |

## Test plan

- [x] All 187 tests pass (`composer test`)
- [x] Code style passes (`vendor/bin/pint --test`)
- [x] Static analysis passes (`composer analyse`)
- [x] Coverage meets 80% minimum threshold (97.9%)