### PR TITLE
fix: resolve phpstan/larastan errors for ScopedLogManager methods (#24)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Tibbs\\ScopedLogger\\": "src/"
+            "Tibbs\\ScopedLogger\\": "src/",
+            "Tibbs\\ScopedLogger\\PHPStan\\": "phpstan/"
         }
     },
     "autoload-dev": {
@@ -67,6 +68,11 @@
             "aliases": {
                 "ScopedLogger": "Tibbs\\ScopedLogger\\Facades\\ScopedLogger"
             }
+        },
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
         }
     },
     "minimum-stability": "stable"

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,5 @@
+services:
+    -
+        class: Tibbs\ScopedLogger\PHPStan\LogFacadeExtension
+        tags:
+            - phpstan.broker.methodsClassReflectionExtension

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 includes:
 #    - phpstan-baseline.neon
+    - extension.neon
 
 parameters:
     level: max

--- a/phpstan/LogFacadeExtension.php
+++ b/phpstan/LogFacadeExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tibbs\ScopedLogger\PHPStan;
+
+use Illuminate\Support\Facades\Log;
+use PHPStan\Analyser\OutOfClassScope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ReflectionProvider;
+use Tibbs\ScopedLogger\ScopedLogManager;
+
+/**
+ * PHPStan extension that teaches static analysis that the Log facade exposes
+ * the five ScopedLogManager-specific methods (scope, setRuntimeLevel, etc.)
+ * in addition to the standard log methods.
+ *
+ * Larastan already stubs Illuminate\Support\Facades\Log and
+ * Illuminate\Log\LogManager so we cannot add @method annotations via a stub
+ * file (phpstan treats duplicate class declarations as a non-ignorable error).
+ * Instead we forward method lookups on the Log facade to ScopedLogManager.
+ */
+class LogFacadeExtension implements MethodsClassReflectionExtension
+{
+    /** @var list<string> */
+    private const SCOPED_LOGGER_METHODS = [
+        'scope',
+        'setRuntimeLevel',
+        'clearRuntimeLevel',
+        'clearAllRuntimeLevels',
+        'getRuntimeLevels',
+    ];
+
+    public function __construct(private ReflectionProvider $reflectionProvider)
+    {
+    }
+
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        return $classReflection->getName() === Log::class
+            && in_array($methodName, self::SCOPED_LOGGER_METHODS, true);
+    }
+
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return $this->reflectionProvider
+            ->getClass(ScopedLogManager::class)
+            ->getMethod($methodName, new OutOfClassScope());
+    }
+}

--- a/phpstan/LogFacadeExtension.php
+++ b/phpstan/LogFacadeExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tibbs\ScopedLogger\PHPStan;
 
+use Illuminate\Log\LogManager;
 use Illuminate\Support\Facades\Log;
 use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Reflection\ClassReflection;
@@ -13,14 +14,19 @@ use PHPStan\Reflection\ReflectionProvider;
 use Tibbs\ScopedLogger\ScopedLogManager;
 
 /**
- * PHPStan extension that teaches static analysis that the Log facade exposes
- * the five ScopedLogManager-specific methods (scope, setRuntimeLevel, etc.)
- * in addition to the standard log methods.
+ * PHPStan extension that teaches static analysis that the Log facade and the
+ * underlying LogManager expose the five ScopedLogManager-specific methods
+ * (scope, setRuntimeLevel, etc.) in addition to the standard log methods.
  *
  * Larastan already stubs Illuminate\Support\Facades\Log and
  * Illuminate\Log\LogManager so we cannot add @method annotations via a stub
  * file (phpstan treats duplicate class declarations as a non-ignorable error).
- * Instead we forward method lookups on the Log facade to ScopedLogManager.
+ * Instead we forward method lookups on those classes to ScopedLogManager.
+ *
+ * The extension matches both Log::class (in case phpstan queries through the
+ * facade directly) and LogManager::class (the class larastan resolves the Log
+ * facade to after dereferencing — this is the path that actually triggers in
+ * practice for chained calls like Log::scope('x')->info('y')).
  */
 class LogFacadeExtension implements MethodsClassReflectionExtension
 {
@@ -39,14 +45,22 @@ class LogFacadeExtension implements MethodsClassReflectionExtension
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        return $classReflection->getName() === Log::class
-            && in_array($methodName, self::SCOPED_LOGGER_METHODS, true);
+        if (! in_array($methodName, self::SCOPED_LOGGER_METHODS, true)) {
+            return false;
+        }
+
+        $className = $classReflection->getName();
+
+        return $className === Log::class
+            || $className === LogManager::class;
     }
 
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
-        return $this->reflectionProvider
+        $reflection = $this->reflectionProvider
             ->getClass(ScopedLogManager::class)
             ->getMethod($methodName, new OutOfClassScope());
+
+        return new StaticMethodReflectionDecorator($reflection);
     }
 }

--- a/phpstan/LogFacadeExtension.php
+++ b/phpstan/LogFacadeExtension.php
@@ -39,9 +39,7 @@ class LogFacadeExtension implements MethodsClassReflectionExtension
         'getRuntimeLevels',
     ];
 
-    public function __construct(private ReflectionProvider $reflectionProvider)
-    {
-    }
+    public function __construct(private ReflectionProvider $reflectionProvider) {}
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
@@ -59,7 +57,7 @@ class LogFacadeExtension implements MethodsClassReflectionExtension
     {
         $reflection = $this->reflectionProvider
             ->getClass(ScopedLogManager::class)
-            ->getMethod($methodName, new OutOfClassScope());
+            ->getMethod($methodName, new OutOfClassScope);
 
         return new StaticMethodReflectionDecorator($reflection);
     }

--- a/phpstan/StaticMethodReflectionDecorator.php
+++ b/phpstan/StaticMethodReflectionDecorator.php
@@ -7,6 +7,7 @@ namespace Tibbs\ScopedLogger\PHPStan;
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Type;
 
@@ -25,9 +26,7 @@ use PHPStan\Type\Type;
  */
 final class StaticMethodReflectionDecorator implements MethodReflection
 {
-    public function __construct(private readonly MethodReflection $wrapped)
-    {
-    }
+    public function __construct(private readonly MethodReflection $wrapped) {}
 
     public function getDeclaringClass(): ClassReflection
     {
@@ -68,7 +67,7 @@ final class StaticMethodReflectionDecorator implements MethodReflection
         return $this->wrapped->getPrototype();
     }
 
-    /** @return list<\PHPStan\Reflection\ParametersAcceptor> */
+    /** @return list<ParametersAcceptor> */
     public function getVariants(): array
     {
         return $this->wrapped->getVariants();

--- a/phpstan/StaticMethodReflectionDecorator.php
+++ b/phpstan/StaticMethodReflectionDecorator.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tibbs\ScopedLogger\PHPStan;
+
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Type;
+
+/**
+ * Wraps a MethodReflection and overrides isStatic() to return true.
+ *
+ * When phpstan resolves a Log facade call (e.g. Log::scope()), the call site is
+ * a static call. Our LogFacadeExtension returns a reflection for a ScopedLogManager
+ * instance method (isStatic() === false). PHPStan then raises method.staticCall
+ * because the reflection disagrees with the call site.
+ *
+ * This decorator fixes the mismatch by reporting the method as static while
+ * delegating all other interface methods to the wrapped reflection unchanged.
+ *
+ * @internal
+ */
+final class StaticMethodReflectionDecorator implements MethodReflection
+{
+    public function __construct(private readonly MethodReflection $wrapped)
+    {
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->wrapped->getDeclaringClass();
+    }
+
+    /**
+     * Always returns true so phpstan accepts this reflection at a static call site
+     * (e.g. Log::scope(...)) without raising method.staticCall.
+     */
+    public function isStatic(): bool
+    {
+        return true;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->wrapped->isPrivate();
+    }
+
+    public function isPublic(): bool
+    {
+        return $this->wrapped->isPublic();
+    }
+
+    public function getDocComment(): ?string
+    {
+        return $this->wrapped->getDocComment();
+    }
+
+    public function getName(): string
+    {
+        return $this->wrapped->getName();
+    }
+
+    public function getPrototype(): ClassMemberReflection
+    {
+        return $this->wrapped->getPrototype();
+    }
+
+    /** @return list<\PHPStan\Reflection\ParametersAcceptor> */
+    public function getVariants(): array
+    {
+        return $this->wrapped->getVariants();
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return $this->wrapped->isDeprecated();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return $this->wrapped->getDeprecatedDescription();
+    }
+
+    public function isFinal(): TrinaryLogic
+    {
+        return $this->wrapped->isFinal();
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return $this->wrapped->isInternal();
+    }
+
+    public function getThrowType(): ?Type
+    {
+        return $this->wrapped->getThrowType();
+    }
+
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return $this->wrapped->hasSideEffects();
+    }
+}

--- a/src/ScopedLogManager.php
+++ b/src/ScopedLogManager.php
@@ -102,6 +102,11 @@ class ScopedLogManager extends LogManager
         return $this->resolveScopedChannel(__FUNCTION__)->scope($scope);
     }
 
+    public function setRuntimeLevel(string $scope, string|false $level): ScopedLogger
+    {
+        return $this->resolveScopedChannel(__FUNCTION__)->setRuntimeLevel($scope, $level);
+    }
+
     /**
      * Dynamically call the default driver instance.
      *

--- a/src/ScopedLogManager.php
+++ b/src/ScopedLogManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tibbs\ScopedLogger;
 
 use Illuminate\Log\LogManager;
+use LogicException;
 use Psr\Log\LoggerInterface;
 use Tibbs\ScopedLogger\Configuration\Configuration;
 
@@ -66,6 +67,31 @@ class ScopedLogManager extends LogManager
 
         // Default: wrap all channels (global by default)
         return true;
+    }
+
+    /**
+     * Resolve the default channel and assert it is a ScopedLogger.
+     *
+     * Used by the explicit delegation methods below so static analyzers
+     * (phpstan, larastan) can see that package-specific methods like
+     * scope() and setRuntimeLevel() exist on the class bound to `log`.
+     */
+    private function resolveScopedChannel(string $method): ScopedLogger
+    {
+        $channel = $this->channel();
+
+        if (! $channel instanceof ScopedLogger) {
+            throw new LogicException(sprintf(
+                'Cannot call %s() on the default channel because it is not wrapped by ScopedLogger. '
+                .'Check that scoped-logger is enabled and the default channel is not listed in '
+                .'scoped-logger.disabled_channels. Use Log::channel(\'other\')->%s(...) '
+                .'to target a specific scoped channel directly.',
+                $method,
+                $method
+            ));
+        }
+
+        return $channel;
     }
 
     /**

--- a/src/ScopedLogManager.php
+++ b/src/ScopedLogManager.php
@@ -107,6 +107,11 @@ class ScopedLogManager extends LogManager
         return $this->resolveScopedChannel(__FUNCTION__)->setRuntimeLevel($scope, $level);
     }
 
+    public function clearRuntimeLevel(string $scope): ScopedLogger
+    {
+        return $this->resolveScopedChannel(__FUNCTION__)->clearRuntimeLevel($scope);
+    }
+
     /**
      * Dynamically call the default driver instance.
      *

--- a/src/ScopedLogManager.php
+++ b/src/ScopedLogManager.php
@@ -112,6 +112,11 @@ class ScopedLogManager extends LogManager
         return $this->resolveScopedChannel(__FUNCTION__)->clearRuntimeLevel($scope);
     }
 
+    public function clearAllRuntimeLevels(): ScopedLogger
+    {
+        return $this->resolveScopedChannel(__FUNCTION__)->clearAllRuntimeLevels();
+    }
+
     /**
      * Dynamically call the default driver instance.
      *

--- a/src/ScopedLogManager.php
+++ b/src/ScopedLogManager.php
@@ -95,6 +95,14 @@ class ScopedLogManager extends LogManager
     }
 
     /**
+     * @param  string|array<int, string>  $scope
+     */
+    public function scope(string|array $scope): ScopedLogger
+    {
+        return $this->resolveScopedChannel(__FUNCTION__)->scope($scope);
+    }
+
+    /**
      * Dynamically call the default driver instance.
      *
      * This ensures that calls like Log::info(), Log::scope(), etc.

--- a/src/ScopedLogManager.php
+++ b/src/ScopedLogManager.php
@@ -33,7 +33,7 @@ class ScopedLogManager extends LogManager
         $channelNameString = is_string($channelName) ? $channelName : 'default';
 
         // Check if this channel should be wrapped
-        if ($this->shouldWrapChannel($channel, $config)) {
+        if ($this->shouldWrapChannel($channelNameString, $config)) {
             return new ScopedLogger($logger, $config, $channelNameString);
         }
 
@@ -51,14 +51,12 @@ class ScopedLogManager extends LogManager
     /**
      * Check if a channel should be wrapped with ScopedLogger
      */
-    protected function shouldWrapChannel(?string $channel, Configuration $config): bool
+    protected function shouldWrapChannel(string $channel, Configuration $config): bool
     {
         // If scoped logger is disabled globally, don't wrap
         if (! $config->isEnabled()) {
             return false;
         }
-
-        $channel = $channel ?? $this->getDefaultDriver();
 
         // Check if channel is in disabled list
         if (in_array($channel, $config->disabledChannels())) {

--- a/src/ScopedLogManager.php
+++ b/src/ScopedLogManager.php
@@ -118,6 +118,14 @@ class ScopedLogManager extends LogManager
     }
 
     /**
+     * @return array<string, string|false>
+     */
+    public function getRuntimeLevels(): array
+    {
+        return $this->resolveScopedChannel(__FUNCTION__)->getRuntimeLevels();
+    }
+
+    /**
      * Dynamically call the default driver instance.
      *
      * This ensures that calls like Log::info(), Log::scope(), etc.

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -104,4 +104,29 @@ describe('ScopedLogManager delegation methods', function () {
 
         expect($resolver->getExplicitScopes())->toBe(['payment']);
     });
+
+    it('setRuntimeLevel() exists on ScopedLogManager and returns a ScopedLogger', function () {
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        $result = $manager->setRuntimeLevel('payment', 'error');
+
+        expect($result)->toBeInstanceOf(ScopedLogger::class);
+    });
+
+    it('setRuntimeLevel() on manager forwards to a ScopedLogger instance', function () {
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        // Delegation smoke test: call returns a ScopedLogger with the level set on it.
+        // We assert on the returned object itself — NOT via $manager->channel() — because
+        // ScopedLogManager::channel() constructs a fresh wrapper on every call (pre-existing
+        // bug tracked separately). The returned instance is guaranteed to be the same one
+        // the mutation ran on.
+        $returned = $manager->setRuntimeLevel('payment', 'error');
+
+        expect($returned)->toBeInstanceOf(ScopedLogger::class);
+        expect($returned->getRuntimeLevels())->toHaveKey('payment');
+        expect($returned->getRuntimeLevels()['payment'])->toBe('error');
+    });
 });

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -146,4 +146,13 @@ describe('ScopedLogManager delegation methods', function () {
         // pre-existing bug tracked separately). We only assert the method exists
         // and returns the correct type.
     });
+
+    it('clearAllRuntimeLevels() on manager forwards to a ScopedLogger instance', function () {
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        $returned = $manager->clearAllRuntimeLevels();
+        expect($returned)->toBeInstanceOf(ScopedLogger::class);
+        expect($returned->getRuntimeLevels())->toBe([]);
+    });
 });

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -68,3 +68,40 @@ describe('ScopedLogManager', function () {
             ->not->toThrow(Exception::class);
     });
 });
+
+describe('ScopedLogManager delegation methods', function () {
+    beforeEach(function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.disabled_channels' => [],
+            'scoped-logger.scopes' => [
+                'payment' => 'debug',
+            ],
+            'scoped-logger.default_level' => 'info',
+        ]);
+    });
+
+    it('scope() exists on ScopedLogManager and returns a ScopedLogger', function () {
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        $result = $manager->scope('payment');
+
+        expect($result)->toBeInstanceOf(ScopedLogger::class);
+    });
+
+    it('scope() on manager delegates to the default channel with the scope applied', function () {
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        $scoped = $manager->scope('payment');
+
+        // Verify that 'payment' was actually passed through to the ScopedLogger's resolver —
+        // this would fail if resolveScopedChannel() returned the channel without calling ->scope($scope)
+        $ref = new \ReflectionProperty($scoped, 'scopeResolver');
+        $ref->setAccessible(true);
+        $resolver = $ref->getValue($scoped);
+
+        expect($resolver->getExplicitScopes())->toBe(['payment']);
+    });
+});

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -129,4 +129,21 @@ describe('ScopedLogManager delegation methods', function () {
         expect($returned->getRuntimeLevels())->toHaveKey('payment');
         expect($returned->getRuntimeLevels()['payment'])->toBe('error');
     });
+
+    it('clearRuntimeLevel() on manager forwards to a ScopedLogger instance', function () {
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        // Set a level and clear it on the same returned instance
+        $withLevel = $manager->setRuntimeLevel('payment', 'error');
+        expect($withLevel->getRuntimeLevels())->toHaveKey('payment');
+
+        $returned = $manager->clearRuntimeLevel('payment');
+        expect($returned)->toBeInstanceOf(ScopedLogger::class);
+
+        // Note: $returned is a different ScopedLogger instance than $withLevel
+        // (ScopedLogManager::channel() constructs a fresh wrapper on every call,
+        // pre-existing bug tracked separately). We only assert the method exists
+        // and returns the correct type.
+    });
 });

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -98,7 +98,7 @@ describe('ScopedLogManager delegation methods', function () {
 
         // Verify that 'payment' was actually passed through to the ScopedLogger's resolver —
         // this would fail if resolveScopedChannel() returned the channel without calling ->scope($scope)
-        $ref = new \ReflectionProperty($scoped, 'scopeResolver');
+        $ref = new ReflectionProperty($scoped, 'scopeResolver');
         $ref->setAccessible(true);
         $resolver = $ref->getValue($scoped);
 

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -155,4 +155,13 @@ describe('ScopedLogManager delegation methods', function () {
         expect($returned)->toBeInstanceOf(ScopedLogger::class);
         expect($returned->getRuntimeLevels())->toBe([]);
     });
+
+    it('getRuntimeLevels() on manager returns an array', function () {
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        $result = $manager->getRuntimeLevels();
+
+        expect($result)->toBeArray();
+    });
 });

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -164,4 +164,64 @@ describe('ScopedLogManager delegation methods', function () {
 
         expect($result)->toBeArray();
     });
+
+    describe('with disabled default channel', function () {
+        beforeEach(function () {
+            // Laravel's default log channel in Testbench is 'stack'.
+            // Put it in disabled_channels so ScopedLogManager::channel()
+            // returns the raw Laravel logger, not a ScopedLogger.
+            config([
+                'scoped-logger.enabled' => true,
+                'scoped-logger.disabled_channels' => ['stack'],
+                'scoped-logger.scopes' => [],
+                'scoped-logger.default_level' => 'info',
+            ]);
+        });
+
+        it('scope() throws LogicException with guidance', function () {
+            $manager = Log::getFacadeRoot();
+            assert($manager instanceof ScopedLogManager);
+
+            expect(fn () => $manager->scope('payment'))
+                ->toThrow(
+                    LogicException::class,
+                    'Cannot call scope() on the default channel because it is not wrapped by ScopedLogger'
+                );
+        });
+
+        it('setRuntimeLevel() throws LogicException with guidance', function () {
+            $manager = Log::getFacadeRoot();
+            assert($manager instanceof ScopedLogManager);
+
+            expect(fn () => $manager->setRuntimeLevel('payment', 'error'))
+                ->toThrow(
+                    LogicException::class,
+                    'Cannot call setRuntimeLevel() on the default channel'
+                );
+        });
+
+        it('clearRuntimeLevel() throws LogicException', function () {
+            $manager = Log::getFacadeRoot();
+            assert($manager instanceof ScopedLogManager);
+
+            expect(fn () => $manager->clearRuntimeLevel('payment'))
+                ->toThrow(LogicException::class, 'Cannot call clearRuntimeLevel()');
+        });
+
+        it('clearAllRuntimeLevels() throws LogicException', function () {
+            $manager = Log::getFacadeRoot();
+            assert($manager instanceof ScopedLogManager);
+
+            expect(fn () => $manager->clearAllRuntimeLevels())
+                ->toThrow(LogicException::class, 'Cannot call clearAllRuntimeLevels()');
+        });
+
+        it('getRuntimeLevels() throws LogicException', function () {
+            $manager = Log::getFacadeRoot();
+            assert($manager instanceof ScopedLogManager);
+
+            expect(fn () => $manager->getRuntimeLevels())
+                ->toThrow(LogicException::class, 'Cannot call getRuntimeLevels()');
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Resolves #24. Adds explicit delegation methods to `ScopedLogManager` and a PHPStan extension so that all consumer call-site forms pass `phpstan analyse` at `level: max` with zero `method.notFound`, `method.nonObject`, or `staticMethod.notFound` errors.

### What changed

- **Five delegation methods on `ScopedLogManager`** — `scope()`, `setRuntimeLevel()`, `clearRuntimeLevel()`, `clearAllRuntimeLevels()`, `getRuntimeLevels()`. Each resolves the default channel via a shared private `resolveScopedChannel()` helper, verifies it is a `ScopedLogger`, and forwards. If the default channel is disabled (globally or per-channel), throws a clear `LogicException` with guidance instead of the previous confusing `BadMethodCallException`.

- **PHPStan `MethodsClassReflectionExtension`** (`phpstan/LogFacadeExtension.php`) — teaches phpstan that the `Log` facade (and the underlying `LogManager` that larastan resolves it to) exposes these five methods. Returns `ScopedLogManager`'s method reflection wrapped in a `StaticMethodReflectionDecorator` so phpstan sees correct parameter types, return types, and static-call semantics.

- **Auto-loaded via `phpstan/extension-installer`** — consumers with `phpstan/extension-installer` (standard in larastan setups) get the extension automatically. No manual `includes:` needed.

### Why a stub file didn't work

Larastan already declares `Illuminate\Support\Facades\Log` and `Illuminate\Log\LogManager` in its own stub files. PHPStan treats duplicate class declarations as a non-ignorable error, so a stub-file approach was not viable. The `MethodsClassReflectionExtension` approach avoids this conflict entirely.

### Consumer verification

Verified against a real Laravel 13 + larastan 3.9.5 consumer project (`scoped-logger-test-consumer`) at phpstan `level: max`. All seven call-site forms from the issue pass with zero errors:

```php
Log::scope('payment')->info('test');              // ✅
logger()->scope('payment')->info('test');         // ✅
app('log')->scope('payment')->info('test');       // ✅
Log::setRuntimeLevel('payment', 'error');         // ✅
Log::clearRuntimeLevel('payment');                // ✅
Log::clearAllRuntimeLevels();                     // ✅
$levels = Log::getRuntimeLevels();                // ✅
```

### Related issues surfaced during implementation

- **Channel-caching bug:** `ScopedLogManager::channel()` constructs a new `ScopedLogger` on every call, so runtime-level mutations don't persist across calls. Pre-existing, independent of this PR. Will file separately.
- **`setAccessible()` deprecation** on `ScopeResolver.php:210` — pre-existing, unrelated. Will fix on a separate branch.

## Test plan

- [x] 220 tests passing (12 new: delegation tests + disabled-channel guard tests)
- [x] `composer analyse` — zero errors at level max
- [x] `vendor/bin/pint --test` — clean
- [x] Consumer verification with real Laravel 13 + larastan 3.9.5 project