### PR TITLE
fix: cache ScopedLogger wrappers per channel to preserve state

### DIFF
--- a/src/ScopedLogManager.php
+++ b/src/ScopedLogManager.php
@@ -11,6 +11,9 @@ use Tibbs\ScopedLogger\Configuration\Configuration;
 
 class ScopedLogManager extends LogManager
 {
+    /** @var array<string, ScopedLogger> */
+    protected array $wrappedChannels = [];
+
     public function __construct(
         protected LogManager $originalLogManager,
         $app
@@ -34,7 +37,11 @@ class ScopedLogManager extends LogManager
 
         // Check if this channel should be wrapped
         if ($this->shouldWrapChannel($channelNameString, $config)) {
-            return new ScopedLogger($logger, $config, $channelNameString);
+            if (! isset($this->wrappedChannels[$channelNameString])) {
+                $this->wrappedChannels[$channelNameString] = new ScopedLogger($logger, $config, $channelNameString);
+            }
+
+            return $this->wrappedChannels[$channelNameString];
         }
 
         return $logger;

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -119,10 +119,6 @@ describe('ScopedLogManager delegation methods', function () {
         assert($manager instanceof ScopedLogManager);
 
         // Delegation smoke test: call returns a ScopedLogger with the level set on it.
-        // We assert on the returned object itself — NOT via $manager->channel() — because
-        // ScopedLogManager::channel() constructs a fresh wrapper on every call (pre-existing
-        // bug tracked separately). The returned instance is guaranteed to be the same one
-        // the mutation ran on.
         $returned = $manager->setRuntimeLevel('payment', 'error');
 
         expect($returned)->toBeInstanceOf(ScopedLogger::class);
@@ -140,11 +136,6 @@ describe('ScopedLogManager delegation methods', function () {
 
         $returned = $manager->clearRuntimeLevel('payment');
         expect($returned)->toBeInstanceOf(ScopedLogger::class);
-
-        // Note: $returned is a different ScopedLogger instance than $withLevel
-        // (ScopedLogManager::channel() constructs a fresh wrapper on every call,
-        // pre-existing bug tracked separately). We only assert the method exists
-        // and returns the correct type.
     });
 
     it('clearAllRuntimeLevels() on manager forwards to a ScopedLogger instance', function () {
@@ -223,5 +214,69 @@ describe('ScopedLogManager delegation methods', function () {
             expect(fn () => $manager->getRuntimeLevels())
                 ->toThrow(LogicException::class, 'Cannot call getRuntimeLevels()');
         });
+    });
+});
+
+describe('ScopedLogManager channel caching', function () {
+    beforeEach(function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.disabled_channels' => [],
+            'scoped-logger.scopes' => [
+                'payment' => 'debug',
+            ],
+            'scoped-logger.default_level' => 'info',
+        ]);
+    });
+
+    it('returns the same ScopedLogger instance for the same channel', function () {
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        $first = $manager->channel();
+        $second = $manager->channel();
+
+        expect($first)->toBe($second);
+    });
+
+    it('returns different ScopedLogger instances for different channels', function () {
+        config(['logging.channels.single' => ['driver' => 'single', 'path' => storage_path('logs/laravel.log')]]);
+
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        $default = $manager->channel();
+        $single = $manager->channel('single');
+
+        expect($default)->not->toBe($single);
+    });
+
+    it('preserves runtime levels set via the manager across channel calls', function () {
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        $channel = $manager->channel();
+        assert($channel instanceof ScopedLogger);
+        $channel->setRuntimeLevel('payment', 'error');
+
+        $sameChannel = $manager->channel();
+        assert($sameChannel instanceof ScopedLogger);
+
+        expect($sameChannel->getRuntimeLevels())->toHaveKey('payment');
+        expect($sameChannel->getRuntimeLevels()['payment'])->toBe('error');
+    });
+
+    it('preserves shared context across channel calls', function () {
+        $manager = Log::getFacadeRoot();
+        assert($manager instanceof ScopedLogManager);
+
+        $channel = $manager->channel();
+        assert($channel instanceof ScopedLogger);
+        $channel->withContext(['request_id' => 'abc123']);
+
+        $sameChannel = $manager->channel();
+
+        // The same instance should have the context
+        expect($sameChannel)->toBe($channel);
     });
 });


### PR DESCRIPTION
## Summary

`ScopedLogManager::channel()` was constructing a new `ScopedLogger` on every call. Since `ScopedLogger` holds per-instance state (`$runtimeLevels`, `$sharedContext`, explicit scopes), mutations were silently lost:

```php
Log::setRuntimeLevel('payment', 'error');  // mutates wrapper A
Log::info('hello');                         // creates wrapper B — override lost
```

The fix caches `ScopedLogger` wrappers in a `$wrappedChannels` array keyed by channel name, matching the caching behavior of Laravel's own `LogManager`.

## Test plan

- [x] New regression tests verify same-instance identity across `channel()` calls
- [x] Tests verify runtime-level and shared-context persistence
- [x] Tests verify different channels get different wrappers
- [x] Full test suite passes
- [x] `composer analyse` clean
- [x] `vendor/bin/pint --test` clean