### PR TITLE
fix: remove deprecated setAccessible() calls from ScopeResolver

### DIFF
--- a/src/Support/ScopeResolver.php
+++ b/src/Support/ScopeResolver.php
@@ -207,7 +207,6 @@ class ScopeResolver
 
                 // Only read public or protected static properties
                 if ($property->isStatic() && ($property->isPublic() || $property->isProtected())) {
-                    $property->setAccessible(true);
                     $result = $property->getValue();
 
                     return $this->normalizeScopeValue($result);


### PR DESCRIPTION
## Summary

Removes unnecessary `setAccessible(true)` calls from `ScopeResolver`. PHP 8.1+ makes reflected properties/methods accessible by default. Since the package requires PHP 8.3+, these calls are dead code that emit deprecation notices on PHP 8.5+ and trigger phpstan's `method.deprecated` rule.

## Test plan

- [x] Full test suite passes
- [x] `composer analyse` clean (the pre-existing `method.deprecated` error is now gone)
- [x] `vendor/bin/pint --test` clean