### PR TITLE
feat: pass-through scoped API when scoped logging is disabled

### DIFF
--- a/src/Contracts/ScopedLoggerContract.php
+++ b/src/Contracts/ScopedLoggerContract.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tibbs\ScopedLogger\Contracts;
+
+use Psr\Log\LoggerInterface;
+use Tibbs\ScopedLogger\PassThroughScopedLogger;
+use Tibbs\ScopedLogger\ScopedLogger;
+
+/**
+ * Contract implemented by any logger exposing the scoped-logger fluent API.
+ *
+ * Implemented by {@see ScopedLogger} (active) and
+ * {@see PassThroughScopedLogger} (no-op fallback used
+ * when scoped logging is disabled globally or for a specific channel).
+ */
+interface ScopedLoggerContract extends LoggerInterface
+{
+    /**
+     * @param  string|array<int, string>  $scope
+     */
+    public function scope(string|array $scope): static;
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function withContext(array $context = []): static;
+
+    public function withoutContext(): static;
+
+    public function setRuntimeLevel(string $scope, string|false $level): static;
+
+    public function clearRuntimeLevel(string $scope): static;
+
+    public function clearAllRuntimeLevels(): static;
+
+    /**
+     * @return array<string, string|false>
+     */
+    public function getRuntimeLevels(): array;
+}

--- a/src/PassThroughScopedLogger.php
+++ b/src/PassThroughScopedLogger.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tibbs\ScopedLogger;
+
+use Psr\Log\LoggerInterface;
+use Stringable;
+use Tibbs\ScopedLogger\Contracts\ScopedLoggerContract;
+
+/**
+ * Pass-through wrapper used when scoped logging is disabled (globally via
+ * config, or for a specific channel via `disabled_channels`).
+ *
+ * Accepts the scoped-logger fluent API (scope, setRuntimeLevel, etc.) as
+ * silent no-ops so that application code like `Log::scope('x')->info(...)`
+ * keeps working without raising errors when the package is turned off.
+ * PSR-3 methods delegate directly to the underlying Laravel logger.
+ */
+class PassThroughScopedLogger implements ScopedLoggerContract
+{
+    public function __construct(
+        protected LoggerInterface $logger,
+    ) {}
+
+    /**
+     * @param  string|array<int, string>  $scope
+     */
+    public function scope(string|array $scope): static
+    {
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function withContext(array $context = []): static
+    {
+        return $this;
+    }
+
+    public function withoutContext(): static
+    {
+        return $this;
+    }
+
+    public function setRuntimeLevel(string $scope, string|false $level): static
+    {
+        return $this;
+    }
+
+    public function clearRuntimeLevel(string $scope): static
+    {
+        return $this;
+    }
+
+    public function clearAllRuntimeLevels(): static
+    {
+        return $this;
+    }
+
+    /**
+     * @return array<string, string|false>
+     */
+    public function getRuntimeLevels(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function emergency(string|Stringable $message, array $context = []): void
+    {
+        $this->logger->emergency($message, $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function alert(string|Stringable $message, array $context = []): void
+    {
+        $this->logger->alert($message, $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function critical(string|Stringable $message, array $context = []): void
+    {
+        $this->logger->critical($message, $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function error(string|Stringable $message, array $context = []): void
+    {
+        $this->logger->error($message, $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function warning(string|Stringable $message, array $context = []): void
+    {
+        $this->logger->warning($message, $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function notice(string|Stringable $message, array $context = []): void
+    {
+        $this->logger->notice($message, $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function info(string|Stringable $message, array $context = []): void
+    {
+        $this->logger->info($message, $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function debug(string|Stringable $message, array $context = []): void
+    {
+        $this->logger->debug($message, $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $this->logger->log($level, $message, $context);
+    }
+
+    /**
+     * Forward any other method calls (e.g. Laravel logger extensions) to the
+     * underlying logger so channel-specific features keep working.
+     *
+     * @param  array<int, mixed>  $parameters
+     */
+    public function __call(string $method, array $parameters): mixed
+    {
+        return $this->logger->$method(...$parameters);
+    }
+}

--- a/src/ScopedLogManager.php
+++ b/src/ScopedLogManager.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Tibbs\ScopedLogger;
 
 use Illuminate\Log\LogManager;
-use LogicException;
-use Psr\Log\LoggerInterface;
 use Tibbs\ScopedLogger\Configuration\Configuration;
+use Tibbs\ScopedLogger\Contracts\ScopedLoggerContract;
 
 class ScopedLogManager extends LogManager
 {
-    /** @var array<string, ScopedLogger> */
+    /** @var array<string, ScopedLoggerContract> */
     protected array $wrappedChannels = [];
 
     public function __construct(
@@ -22,9 +21,15 @@ class ScopedLogManager extends LogManager
     }
 
     /**
-     * Get a log channel instance, wrapped in ScopedLogger
+     * Get a log channel instance.
+     *
+     * Always returns a {@see ScopedLoggerContract} — either an active
+     * {@see ScopedLogger} (when scoped logging is enabled for this channel)
+     * or a {@see PassThroughScopedLogger} (when disabled globally or
+     * for this specific channel). This keeps `Log::scope(...)` and other
+     * fluent calls safe even when the package is turned off.
      */
-    public function channel($channel = null): LoggerInterface
+    public function channel($channel = null): ScopedLoggerContract
     {
         $logger = $this->originalLogManager->channel($channel);
         /** @var array<string, mixed> $configArray */
@@ -32,94 +37,67 @@ class ScopedLogManager extends LogManager
         $config = Configuration::fromArray($configArray);
         $channelName = $channel ?? $this->getDefaultDriver();
 
-        // Ensure channelName is string
         $channelNameString = is_string($channelName) ? $channelName : 'default';
 
-        // Check if this channel should be wrapped
-        if ($this->shouldWrapChannel($channelNameString, $config)) {
-            if (! isset($this->wrappedChannels[$channelNameString])) {
-                $this->wrappedChannels[$channelNameString] = new ScopedLogger($logger, $config, $channelNameString);
-            }
-
+        if (isset($this->wrappedChannels[$channelNameString])) {
             return $this->wrappedChannels[$channelNameString];
         }
 
-        return $logger;
+        $wrapper = $this->shouldWrapChannel($channelNameString, $config)
+            ? new ScopedLogger($logger, $config, $channelNameString)
+            : new PassThroughScopedLogger($logger);
+
+        $this->wrappedChannels[$channelNameString] = $wrapper;
+
+        return $wrapper;
     }
 
     /**
-     * Get a log driver instance (alias for channel)
+     * Get a log driver instance (alias for channel).
      */
-    public function driver($driver = null): LoggerInterface
+    public function driver($driver = null): ScopedLoggerContract
     {
         return $this->channel($driver);
     }
 
     /**
-     * Check if a channel should be wrapped with ScopedLogger
+     * Check if a channel should be wrapped with ScopedLogger (active scoped
+     * logging) versus PassThroughScopedLogger (no-op fallback).
      */
     protected function shouldWrapChannel(string $channel, Configuration $config): bool
     {
-        // If scoped logger is disabled globally, don't wrap
         if (! $config->isEnabled()) {
             return false;
         }
 
-        // Check if channel is in disabled list
         if (in_array($channel, $config->disabledChannels())) {
             return false;
         }
 
-        // Default: wrap all channels (global by default)
         return true;
-    }
-
-    /**
-     * Resolve the default channel and assert it is a ScopedLogger.
-     *
-     * Used by the explicit delegation methods below so static analyzers
-     * (phpstan, larastan) can see that package-specific methods like
-     * scope() and setRuntimeLevel() exist on the class bound to `log`.
-     */
-    private function resolveScopedChannel(string $method): ScopedLogger
-    {
-        $channel = $this->channel();
-
-        if (! $channel instanceof ScopedLogger) {
-            throw new LogicException(sprintf(
-                'Cannot call %s() on the default channel because it is not wrapped by ScopedLogger. '
-                .'Check that scoped-logger is enabled and the default channel is not listed in '
-                .'scoped-logger.disabled_channels. Use Log::channel(\'other\')->%s(...) '
-                .'to target a specific scoped channel directly.',
-                $method,
-                $method
-            ));
-        }
-
-        return $channel;
     }
 
     /**
      * @param  string|array<int, string>  $scope
      */
-    public function scope(string|array $scope): ScopedLogger
+    public function scope(string|array $scope): ScopedLoggerContract
     {
-        return $this->resolveScopedChannel(__FUNCTION__)->scope($scope);
+        return $this->channel()->scope($scope);
     }
 
-    public function setRuntimeLevel(string $scope, string|false $level): ScopedLogger
+    public function setRuntimeLevel(string $scope, string|false $level): ScopedLoggerContract
     {
-        return $this->resolveScopedChannel(__FUNCTION__)->setRuntimeLevel($scope, $level);
+        return $this->channel()->setRuntimeLevel($scope, $level);
     }
 
-    public function clearRuntimeLevel(string $scope): ScopedLogger
+    public function clearRuntimeLevel(string $scope): ScopedLoggerContract
     {
-        return $this->resolveScopedChannel(__FUNCTION__)->clearRuntimeLevel($scope);
+        return $this->channel()->clearRuntimeLevel($scope);
     }
 
-    public function clearAllRuntimeLevels(): ScopedLogger
+    public function clearAllRuntimeLevels(): ScopedLoggerContract
     {
-        return $this->resolveScopedChannel(__FUNCTION__)->clearAllRuntimeLevels();
+        return $this->channel()->clearAllRuntimeLevels();
     }
 
     /**
@@ -127,7 +105,7 @@ class ScopedLogManager extends LogManager
      */
     public function getRuntimeLevels(): array
     {
-        return $this->resolveScopedChannel(__FUNCTION__)->getRuntimeLevels();
+        return $this->channel()->getRuntimeLevels();
     }
 
     /**

--- a/src/ScopedLogger.php
+++ b/src/ScopedLogger.php
@@ -8,12 +8,13 @@ use Closure;
 use Psr\Log\LoggerInterface;
 use Stringable;
 use Tibbs\ScopedLogger\Configuration\Configuration;
+use Tibbs\ScopedLogger\Contracts\ScopedLoggerContract;
 use Tibbs\ScopedLogger\Exceptions\InvalidScopeConfigurationException;
 use Tibbs\ScopedLogger\Exceptions\UnknownScopeException;
 use Tibbs\ScopedLogger\Support\PatternMatcher;
 use Tibbs\ScopedLogger\Support\ScopeResolver;
 
-class ScopedLogger implements LoggerInterface
+class ScopedLogger implements ScopedLoggerContract
 {
     protected ScopeResolver $scopeResolver;
 

--- a/tests/PassThroughScopedLoggerTest.php
+++ b/tests/PassThroughScopedLoggerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Log;
+use Psr\Log\LoggerInterface;
+use Tibbs\ScopedLogger\Contracts\ScopedLoggerContract;
+use Tibbs\ScopedLogger\PassThroughScopedLogger;
+use Tibbs\ScopedLogger\ScopedLogger;
+
+describe('PassThroughScopedLogger - unit', function () {
+    beforeEach(function () {
+        $this->underlying = Mockery::mock(LoggerInterface::class);
+        $this->passThrough = new PassThroughScopedLogger($this->underlying);
+    });
+
+    afterEach(function () {
+        Mockery::close();
+    });
+
+    it('implements ScopedLoggerContract', function () {
+        expect($this->passThrough)->toBeInstanceOf(ScopedLoggerContract::class);
+    });
+
+    it('scope() is a no-op returning itself for chaining', function () {
+        expect($this->passThrough->scope('anything'))->toBe($this->passThrough);
+        expect($this->passThrough->scope(['a', 'b']))->toBe($this->passThrough);
+    });
+
+    it('setRuntimeLevel() is a no-op returning itself', function () {
+        expect($this->passThrough->setRuntimeLevel('payment', 'debug'))->toBe($this->passThrough);
+        expect($this->passThrough->setRuntimeLevel('payment', false))->toBe($this->passThrough);
+    });
+
+    it('clearRuntimeLevel() is a no-op returning itself', function () {
+        expect($this->passThrough->clearRuntimeLevel('payment'))->toBe($this->passThrough);
+    });
+
+    it('clearAllRuntimeLevels() is a no-op returning itself', function () {
+        expect($this->passThrough->clearAllRuntimeLevels())->toBe($this->passThrough);
+    });
+
+    it('getRuntimeLevels() always returns an empty array', function () {
+        expect($this->passThrough->getRuntimeLevels())->toBe([]);
+
+        // Even after calling setRuntimeLevel, it remains empty
+        $this->passThrough->setRuntimeLevel('payment', 'debug');
+        expect($this->passThrough->getRuntimeLevels())->toBe([]);
+    });
+
+    it('withContext() and withoutContext() are no-ops returning itself', function () {
+        expect($this->passThrough->withContext(['x' => 1]))->toBe($this->passThrough);
+        expect($this->passThrough->withoutContext())->toBe($this->passThrough);
+    });
+
+    it('forwards info() to the underlying logger unchanged', function () {
+        $this->underlying->shouldReceive('info')
+            ->once()
+            ->with('hello', ['ctx' => 1]);
+
+        $this->passThrough->info('hello', ['ctx' => 1]);
+    });
+
+    it('forwards each PSR-3 severity method to the underlying logger', function () {
+        foreach (['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'] as $method) {
+            $this->underlying->shouldReceive($method)
+                ->once()
+                ->with('msg', ['k' => 'v']);
+
+            $this->passThrough->$method('msg', ['k' => 'v']);
+        }
+    });
+
+    it('forwards log() with arbitrary level to the underlying logger', function () {
+        $this->underlying->shouldReceive('log')
+            ->once()
+            ->with('warning', 'msg', ['k' => 'v']);
+
+        $this->passThrough->log('warning', 'msg', ['k' => 'v']);
+    });
+
+    it('does not mutate context passed through scoped API methods', function () {
+        $this->underlying->shouldReceive('info')
+            ->once()
+            ->with('hi', []); // no scope/metadata added
+
+        $this->passThrough->scope('payment')->info('hi');
+    });
+});
+
+describe('PassThroughScopedLogger - integration via Log facade', function () {
+    it('chained scope()->info() when globally disabled does not throw', function () {
+        config([
+            'scoped-logger.enabled' => false,
+        ]);
+
+        expect(fn () => Log::scope('anything')->info('hello'))
+            ->not->toThrow(Exception::class);
+    });
+
+    it('Log::channel() returns PassThroughScopedLogger when globally disabled', function () {
+        config([
+            'scoped-logger.enabled' => false,
+        ]);
+
+        $channel = Log::channel();
+
+        expect($channel)->toBeInstanceOf(PassThroughScopedLogger::class);
+        expect($channel)->not->toBeInstanceOf(ScopedLogger::class);
+    });
+
+    it('disabled specific channel: scoped API is safe on that channel', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.disabled_channels' => ['stack'],
+        ]);
+
+        expect(fn () => Log::channel('stack')->scope('x')->setRuntimeLevel('x', 'debug')->info('msg'))
+            ->not->toThrow(Exception::class);
+    });
+
+    it('enabled config still returns an active ScopedLogger (not pass-through)', function () {
+        config([
+            'scoped-logger.enabled' => true,
+            'scoped-logger.disabled_channels' => [],
+            'scoped-logger.default_level' => 'debug',
+            'scoped-logger.scopes' => [],
+            'scoped-logger.auto_detection' => ['enabled' => false],
+        ]);
+
+        $channel = Log::channel();
+
+        expect($channel)->toBeInstanceOf(ScopedLogger::class);
+        expect($channel)->not->toBeInstanceOf(PassThroughScopedLogger::class);
+    });
+});

--- a/tests/PassThroughScopedLoggerTest.php
+++ b/tests/PassThroughScopedLoggerTest.php
@@ -86,6 +86,50 @@ describe('PassThroughScopedLogger - unit', function () {
 
         $this->passThrough->scope('payment')->info('hi');
     });
+
+    it('forwards unknown method calls to the underlying logger via __call', function () {
+        // Laravel's logger exposes extensions beyond PSR-3 (e.g. getLogger()).
+        // Anything not on the scoped-logger API should transparently forward.
+        $underlying = new class implements LoggerInterface
+        {
+            /** @var array<int, array{method: string, args: array<int, mixed>}> */
+            public array $calls = [];
+
+            public function emergency(string|Stringable $message, array $context = []): void {}
+
+            public function alert(string|Stringable $message, array $context = []): void {}
+
+            public function critical(string|Stringable $message, array $context = []): void {}
+
+            public function error(string|Stringable $message, array $context = []): void {}
+
+            public function warning(string|Stringable $message, array $context = []): void {}
+
+            public function notice(string|Stringable $message, array $context = []): void {}
+
+            public function info(string|Stringable $message, array $context = []): void {}
+
+            public function debug(string|Stringable $message, array $context = []): void {}
+
+            public function log($level, string|Stringable $message, array $context = []): void {}
+
+            public function write(string $message, string $channel): string
+            {
+                $this->calls[] = ['method' => 'write', 'args' => [$message, $channel]];
+
+                return "wrote:{$message}:{$channel}";
+            }
+        };
+
+        $passThrough = new PassThroughScopedLogger($underlying);
+
+        $result = $passThrough->write('hello', 'stack');
+
+        expect($result)->toBe('wrote:hello:stack');
+        expect($underlying->calls)->toBe([
+            ['method' => 'write', 'args' => ['hello', 'stack']],
+        ]);
+    });
 });
 
 describe('PassThroughScopedLogger - integration via Log facade', function () {

--- a/tests/ScopedLogManagerTest.php
+++ b/tests/ScopedLogManagerTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Log;
+use Tibbs\ScopedLogger\Contracts\ScopedLoggerContract;
+use Tibbs\ScopedLogger\PassThroughScopedLogger;
 use Tibbs\ScopedLogger\ScopedLogger;
 use Tibbs\ScopedLogger\ScopedLogManager;
 
@@ -18,17 +20,18 @@ describe('ScopedLogManager', function () {
         expect($logger)->toBeInstanceOf(ScopedLogger::class);
     });
 
-    it('returns original logger when scoped logger is disabled', function () {
+    it('returns a PassThroughScopedLogger when scoped logger is disabled', function () {
         config([
             'scoped-logger.enabled' => false,
         ]);
 
         $logger = Log::channel();
 
+        expect($logger)->toBeInstanceOf(PassThroughScopedLogger::class);
         expect($logger)->not->toBeInstanceOf(ScopedLogger::class);
     });
 
-    it('returns original logger for disabled channels', function () {
+    it('returns a PassThroughScopedLogger for disabled channels', function () {
         config([
             'scoped-logger.enabled' => true,
             'scoped-logger.disabled_channels' => ['stack'],
@@ -36,6 +39,7 @@ describe('ScopedLogManager', function () {
 
         $logger = Log::channel('stack');
 
+        expect($logger)->toBeInstanceOf(PassThroughScopedLogger::class);
         expect($logger)->not->toBeInstanceOf(ScopedLogger::class);
     });
 
@@ -156,11 +160,11 @@ describe('ScopedLogManager delegation methods', function () {
         expect($result)->toBeArray();
     });
 
-    describe('with disabled default channel', function () {
+    describe('with disabled default channel (pass-through mode)', function () {
         beforeEach(function () {
             // Laravel's default log channel in Testbench is 'stack'.
             // Put it in disabled_channels so ScopedLogManager::channel()
-            // returns the raw Laravel logger, not a ScopedLogger.
+            // returns a PassThroughScopedLogger, not an active ScopedLogger.
             config([
                 'scoped-logger.enabled' => true,
                 'scoped-logger.disabled_channels' => ['stack'],
@@ -169,50 +173,60 @@ describe('ScopedLogManager delegation methods', function () {
             ]);
         });
 
-        it('scope() throws LogicException with guidance', function () {
+        it('scope() silently no-ops and returns a ScopedLoggerContract', function () {
             $manager = Log::getFacadeRoot();
             assert($manager instanceof ScopedLogManager);
 
-            expect(fn () => $manager->scope('payment'))
-                ->toThrow(
-                    LogicException::class,
-                    'Cannot call scope() on the default channel because it is not wrapped by ScopedLogger'
-                );
+            $result = $manager->scope('payment');
+
+            expect($result)->toBeInstanceOf(ScopedLoggerContract::class);
+            expect($result)->toBeInstanceOf(PassThroughScopedLogger::class);
         });
 
-        it('setRuntimeLevel() throws LogicException with guidance', function () {
+        it('setRuntimeLevel() silently no-ops', function () {
             $manager = Log::getFacadeRoot();
             assert($manager instanceof ScopedLogManager);
 
-            expect(fn () => $manager->setRuntimeLevel('payment', 'error'))
-                ->toThrow(
-                    LogicException::class,
-                    'Cannot call setRuntimeLevel() on the default channel'
-                );
+            $result = $manager->setRuntimeLevel('payment', 'error');
+
+            expect($result)->toBeInstanceOf(PassThroughScopedLogger::class);
+            expect($result->getRuntimeLevels())->toBe([]);
         });
 
-        it('clearRuntimeLevel() throws LogicException', function () {
+        it('clearRuntimeLevel() silently no-ops', function () {
             $manager = Log::getFacadeRoot();
             assert($manager instanceof ScopedLogManager);
 
-            expect(fn () => $manager->clearRuntimeLevel('payment'))
-                ->toThrow(LogicException::class, 'Cannot call clearRuntimeLevel()');
+            $result = $manager->clearRuntimeLevel('payment');
+
+            expect($result)->toBeInstanceOf(PassThroughScopedLogger::class);
         });
 
-        it('clearAllRuntimeLevels() throws LogicException', function () {
+        it('clearAllRuntimeLevels() silently no-ops', function () {
             $manager = Log::getFacadeRoot();
             assert($manager instanceof ScopedLogManager);
 
-            expect(fn () => $manager->clearAllRuntimeLevels())
-                ->toThrow(LogicException::class, 'Cannot call clearAllRuntimeLevels()');
+            $result = $manager->clearAllRuntimeLevels();
+
+            expect($result)->toBeInstanceOf(PassThroughScopedLogger::class);
+            expect($result->getRuntimeLevels())->toBe([]);
         });
 
-        it('getRuntimeLevels() throws LogicException', function () {
+        it('getRuntimeLevels() returns an empty array', function () {
             $manager = Log::getFacadeRoot();
             assert($manager instanceof ScopedLogManager);
 
-            expect(fn () => $manager->getRuntimeLevels())
-                ->toThrow(LogicException::class, 'Cannot call getRuntimeLevels()');
+            expect($manager->getRuntimeLevels())->toBe([]);
+        });
+
+        it('Log::scope(...)->info(...) works end-to-end without error', function () {
+            expect(fn () => Log::scope('anything')->info('test message'))
+                ->not->toThrow(Exception::class);
+        });
+
+        it('chained scope with runtime level works without error', function () {
+            expect(fn () => Log::scope('payment')->setRuntimeLevel('payment', 'debug')->info('msg'))
+                ->not->toThrow(Exception::class);
         });
     });
 });


### PR DESCRIPTION
## Summary
- When `scoped-logger.enabled` is `false` (or the channel is in `disabled_channels`), `ScopedLogManager::channel()` previously returned Laravel's raw logger. That broke application code like `Log::scope('x')->info(...)` with a PHP error, even though the whole point of disabling was "don't do anything fancy".
- Introduce `Tibbs\ScopedLogger\Contracts\ScopedLoggerContract` (extends `Psr\Log\LoggerInterface` with the fluent scoped methods) and a `PassThroughScopedLogger` that implements it: PSR-3 methods delegate to the underlying Laravel logger; scope/runtime methods are silent no-ops returning `$this`.
- `ScopedLogManager::channel()`/`driver()` now **always** return a `ScopedLoggerContract` — an active `ScopedLogger` when scoped logging applies, otherwise a `PassThroughScopedLogger`. `resolveScopedChannel()` and its `LogicException` path are removed because they can't trigger any more.

## Behavior change
- Before: `Log::scope('x')->info('msg')` with scoped logging disabled threw `LogicException` / `BadMethodCallException`.
- After: it's equivalent to `Log::info('msg')` — no error, log goes through Laravel's logger.

## Test plan
- [x] `composer test` — all 241 tests pass (15 new tests added in `tests/PassThroughScopedLoggerTest.php` + updated disabled-channel tests in `tests/ScopedLogManagerTest.php`)
- [x] `composer analyse` — PHPStan max level, no errors
- [x] `vendor/bin/pint --test` — code style clean
- [x] New unit coverage: scope/setRuntimeLevel/clear* are no-ops; PSR-3 forwards verbatim to underlying logger (Mockery)
- [x] New integration coverage via Log facade: globally disabled, per-channel disabled, chained `scope()->setRuntimeLevel()->info()` all safe